### PR TITLE
TG-1969 upgrade minio client

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,7 +15,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   build_and_push:
-    nam: "Build & push image"
+    name: "Build & push image"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -51,7 +51,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: images/webpm/Dockerfile
           push: true
           tags: ${{ steps.docker_metadata.outputs.tags }}
           labels: ${{ steps.docker_metadat.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,13 +26,13 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            registry.gitlab.com/youwol/platform/data-manager
+            registry.gitlab.com/youwol/platform/cluster-data-manager
           tags: |
             type=pep440,pattern={{version}}
             type=raw,enable=${{ inputs.tag != '' }},value=${{ inputs.tag }}
             type=sha
           labels: |
-            org.opencontainers.image.title=youwol/data-manager
+            org.opencontainers.image.title=youwol/cluster-data-manager
 
       - name: Setup Docker Buildx
         id: setup_docker_buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN    apt-get update \
     && apt-get clean \
     && pip install \
        pip=="$pip_version" \
-       pipx=="$pipx_version" \
+       pipx=="$pipx_version"
 # pipx venvs & apps directories in /opt
 ENV PIPX_HOME=/opt/pipx/home
 ENV PIPX_BIN_DIR=/opt/pipx/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM python:3.12-bullseye AS python-builder
 ## Arguments
 #
 # URL for downloading the minio client binary
-ARG mc_bin_url="https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2023-04-12T02-21-51Z"
+ARG mc_bin_url="https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2024-01-28T16-23-14Z"
 # git repository to clone to get cqlsh source
 ARG cqlsh_repository=https://github.com/youwol-jdecharne/scylla-cqlsh.git
 # git commitish to checkout for cqlsh source

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,11 @@ ARG path_data_manager_home=/opt/data-manager
 ## Create user data-manager
 #
 # Create user & user home directory
-RUN useradd -m -d "$path_data_manager_home" data-manager
+RUN useradd \
+    --home-dir "$path_data_manager_home" \
+    --create-home \
+    --uid 10000 \
+    data-manager
 # Use user HOME as the image WORKDIR
 WORKDIR $path_data_manager_home
 
@@ -149,6 +153,6 @@ COPY --from=python-builder /opt /opt
 ## Image entry point
 #
 # Run as user data-manager
-USER data-manager
+USER 10000
 # Start our script, from pipx installation
 ENTRYPOINT ["data-manager"]

--- a/src/youwol/data_manager/assets/kc_common.sh
+++ b/src/youwol/data_manager/assets/kc_common.sh
@@ -8,6 +8,8 @@ exec > >(tee "$PATH_WORK_DIR/script_out.log")
 set -ex
 set -o pipefail
 
+cd "$PATH_WORK_DIR"
+
 trap "echo 'Trapping SIGINT. The script ended with errors'; echo 'ERROR' > '$PATH_KEYCLOAK_STATUS_FILE'; exit 1" INT
 trap "echo 'Trapping SIGTERM . The script ended with errors'; echo 'ERROR' > '$PATH_KEYCLOAK_STATUS_FILE'; exit 1" TERM
 trap "echo 'Trapping SIGABRT. The script ended with errors'; echo 'ERROR' > '$PATH_KEYCLOAK_STATUS_FILE'; exit 1" ABRT
@@ -32,8 +34,11 @@ status INIT
 
 die() {
   msg=$1
+  die_delay=3600
   echo "Fatal: $msg"
   status "ERROR"
+  echo "Will exit with failure in $die_delay seconds"
+  sleep $die_delay
   exit 1
 }
 


### PR DESCRIPTION
- 🐛 `Dockerfile` remove continuation backslash
- 📌 `Dockerfile` use latest minio client release
- 🐛 `docker-image.yml` typo for job key `name`
- 🔒️ `Dockerfile` uid 10000 for user data-amanger
- 🚚 `docker-image.yml` rename `cluster-data-manager`
- 🐛 [kc/common] ch. current dir to `path_work_dir`

TG-1969 #closed